### PR TITLE
add --enable-use-nullsafe-sprintf

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -386,6 +386,10 @@
  */
 @cdef_use_deprecated@ USE_DEPRECATED
 
+/* Define this if you want the legacy %c == \0 handling in 
+ * (s)printf efuns.
+ */
+@cdef_use_nullsafe_sprintf@ USE_NULLSAFE_SPRINTF
 
 /* --- Runtime limits --- */
 

--- a/src/configure
+++ b/src/configure
@@ -709,6 +709,7 @@ cdef_use_gcrypt
 cdef_use_tls
 cdef_use_structs
 cdef_use_deprecated
+cdef_use_nullsafe_sprintf
 cdef_use_builtin_pcre
 cdef_use_pcre
 cdef_use_mccp
@@ -820,6 +821,7 @@ enable_use_pcre
 enable_use_xml
 with_xml_path
 enable_use_deprecated
+enable_use_nullsafe_sprintf
 enable_use_structs
 enable_use_tls
 with_tls_path
@@ -1581,6 +1583,8 @@ Optional Features:
         Enables XML support: no/xml2/iksemel/yes
   --enable-use-deprecated  default=enabled
         Enables obsolete and deprecated efuns
+  --enable-use-nullsafe-sprintf default=disabled
+        Enables legacy %c == \0 handling in (s)printf
   --enable-use-structs  default=enabled
         Enables structs
   --enable-use-tls  default=disabled
@@ -3076,6 +3080,13 @@ if test "${enable_use_deprecated+set}" = set; then :
 fi
 
 
+DEFAULTenable_use_nullsafe_sprintf=no
+# Check whether --enable-use-nullsafe-sprintf was given.
+if test "${enable_use_nullsafe_sprintf+set}" = set; then :
+  enableval=$enable_use_nullsafe_sprintf;
+fi
+
+
 DEFAULTenable_use_structs=yes
 # Check whether --enable-use-structs was given.
 if test "${enable_use_structs+set}" = set; then :
@@ -4116,6 +4127,16 @@ if test "x$enable_use_deprecated" = "xyes"; then
   cdef_use_deprecated="#define"
 else
   cdef_use_deprecated="#undef"
+fi
+
+if test "x$enable_use_nullsafe_sprintf" = "x" && test "x$DEFAULTenable_use_nullsafe_sprintf" != "x"; then
+  enable_use_nullsafe_sprintf=$DEFAULTenable_use_nullsafe_sprintf
+fi
+
+if test "x$enable_use_nullsafe_sprintf" = "xyes"; then
+  cdef_use_nullsafe_sprintf="#define"
+else
+  cdef_use_nullsafe_sprintf="#undef"
 fi
 
 if test "x$enable_use_structs" = "x" && test "x$DEFAULTenable_use_structs" != "x"; then

--- a/src/main.c
+++ b/src/main.c
@@ -1882,6 +1882,10 @@ options (void)
 #ifdef USE_DEPRECATED
                               , "obsolete and deprecated efuns enabled\n"
 #endif
+#ifdef USE_NULLSAFE_SPRINTF
+                              , "legacy null char handling in (s)print efuns "
+                                "enabled\n"
+#endif
 #ifdef NO_NEGATIVE_RANGES
                               , "assignments to negative ranges disabled\n"
 #endif

--- a/src/sprintf.c
+++ b/src/sprintf.c
@@ -2256,7 +2256,9 @@ add_table_now:
                        */
                     double value;   /* The value to print */
                     int    numdig;  /* (Estimated) number of digits before the '.' */
+#ifndef USE_NULLSAFE_SPRINTF
                     Bool zeroCharHack = MY_FALSE;
+#endif
                     char *p = cheat; /* pointer to the format buffer */
                     int tmpl;
 
@@ -2311,8 +2313,12 @@ add_table_now:
                         if (format_char == 'c') {
                             if (carg->u.number == 0)
                             {
+#ifdef USE_NULLSAFE_SPRINTF
+                            format_char = 's';
+#else
                             carg->u.number = 1;
                             zeroCharHack = MY_TRUE;
+#endif
                             }
                         }
                         /* insert the correct length modifier for a p_int
@@ -2325,13 +2331,18 @@ add_table_now:
                         }
                         *(p++) = format_char;
                         *p = '\0';
-                        sprintf(temp, cheat, carg->u.number);
+                        if (format_char == 's') {
+                          sprintf(temp, cheat, "");
+                        } else {
+                          sprintf(temp, cheat, carg->u.number);
+                        }
                         tmpl = strlen(temp);
                         if ((size_t)tmpl >= sizeof(temp))
                             fatal("Local buffer overflow in sprintf() for int.\n");
                         if (pres && tmpl > pres)
                             tmpl = pres; /* well.... */
 
+#ifndef USE_NULLSAFE_SPRINTF
                         if (zeroCharHack)
                         {
                             int pos;
@@ -2341,6 +2352,7 @@ add_table_now:
                                     temp[pos] = 0x00;
                             }
                         }
+#endif
                     }
                     if ((unsigned int)tmpl < fs)
                     {


### PR DESCRIPTION
Previous to 3.3.x `sprintf("hello%cworld\n", 0);` would evaluate to
`"helloworld\n"` - the null character is treated as an empty string. In
3.3.720 however it evaluates to `"hello"` - the null character truncates
the string c-style. This is probably the more sensible behaviour but we
have a lot of legacy lib code that expected to be able to use `0` as
`""` for a `%c` character specifier and now text (like inventory
output!) is suddenly and incorrectly truncated.

Finding all of the instances of this across the lib is a tricky runtime
problem. Since our lib code never expects to be able to `sprintf` a null
character (it wasn't possible previously!) it seems much easier to patch
the driver to restore the original behaviour. Sorry not sorry.

This commit adds a `--enable-use-nullsafe-sprintf` config flag
(defaulting to off) that when enabled, treats `%c` with `0` argument as
a no-op.