### PR TITLE
rm cat|tail|transfer "replace by a simul-efun" warns

### DIFF
--- a/src/func_spec
+++ b/src/func_spec
@@ -585,7 +585,7 @@ int     send_erq(int, int*|string, null|closure default: F_CONST0);
 
         /* Files */
 
-int     cat(string, void|int, void|int) "replace by a simul-efun (see deprecated/cat.c)";
+int     cat(string, void|int, void|int);
 int     copy_file(string, string);
 int     file_size(string);
 mixed  *get_dir(string, int default: F_CONST1);
@@ -595,7 +595,7 @@ string  read_file(string, void|int, void|int);
 int     rename(string, string);
 int     rm(string);
 int     rmdir(string);
-int     tail(string) "replace by a simul-efun (see deprecated/tail.c)";
+int     tail(string);
 int     write_bytes(string, int, string);
 int     write_file(string, string, int default: F_CONST0);
 
@@ -792,7 +792,7 @@ int     set_is_wizard(object, int default: F_CONST1);
         /* Functions only used in compatibility mode.
          */
 
-int     transfer(object, object|string) "replace by a simul-efun";
+int     transfer(object, object|string);
 
 #endif /* USE_DEPRECATED */
 


### PR DESCRIPTION
We know. We know....

I've replaced these (and more) deprecated efuns in the lib branch
targeting 3.5.4. There's no use seeing a ton of warnings for it while we
work on getting 3.3.720 stable.